### PR TITLE
Fix path references in data formatting notebook

### DIFF
--- a/new/rawData/data_formatting.ipynb
+++ b/new/rawData/data_formatting.ipynb
@@ -24,8 +24,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "raw_dir = Path('new/rawData')\n",
-    "output_dir = Path('new/formattedData')\n",
+  "# Use paths relative to this notebook's directory\n",
+  "raw_dir = Path('.')\n",
+  "output_dir = Path('..') / 'formattedData'\n",
     "output_dir.mkdir(exist_ok=True)\n",
     "\n",
     "def load_dataset(path):\n",


### PR DESCRIPTION
## Summary
- fix incorrect path setup in `data_formatting.ipynb`

## Testing
- `python -m py_compile $(git ls-files '*.py')`